### PR TITLE
allow overriding the inet_protocols

### DIFF
--- a/src/bin/setup-postfix.sh
+++ b/src/bin/setup-postfix.sh
@@ -14,6 +14,10 @@ chmod +x /opt/postfix.sh
 postconf -e myhostname=$maildomain
 postconf -F '*/*/chroot = n'
 
+if [ "${inet_protocols}" != "" ]; then
+  postconf -e inet_protocols=$inet_protocols
+fi
+
 if [ "${STRIP_RECEIVED_HEADERS}" = "1" ]; then
   echo "/^Received:.*/ IGNORE" >/etc/postfix/header_checks
   echo "header_checks = pcre:/etc/postfix/header_checks" >>/etc/postfix/main.cf


### PR DESCRIPTION
In order to only `allow` / `use` ipv4 / ipv6 (or `all` default) This should enable setting it via an environment variable (right?)

The possible options are: `ipv4` / `ipv6` / `ipv4,ipv6` / `ipv6,ipv4` / `all` (default)
It should at least check for those options i guess... but this at least is a start?