### PR TITLE
feat: added env option to set stricter rejects; reducing backscatter

### DIFF
--- a/src/bin/setup-postfix.sh
+++ b/src/bin/setup-postfix.sh
@@ -26,3 +26,27 @@ if [ "${STRIP_RECEIVED_HEADERS}" = "1" ]; then
   echo "/^Received:.*/ IGNORE" >/etc/postfix/header_checks
   postconf -e header_checks=pcre:/etc/postfix/header_checks
 fi
+
+if [ "${STRICT}" = "1" ]; then
+  STRICT_REJECT=1
+fi
+
+if [ "${STRICT_REJECT}" = "1" ]; then
+  # reduce backscatter
+  # taken from https://willem.com/blog/2019-09-10_fighting-backscatter-spam-at-server-level/
+  postconf -e smtpd_helo_required=yes
+  postconf -e invalid_hostname_reject_code=554
+  postconf -e multi_recipient_bounce_reject_code=554
+  postconf -e non_fqdn_reject_code=554
+  postconf -e relay_domains_reject_code=554
+  postconf -e unknown_address_reject_code=554
+  postconf -e unknown_client_reject_code=554
+  postconf -e unknown_hostname_reject_code=554
+  postconf -e unknown_local_recipient_reject_code=554
+  postconf -e unknown_relay_recipient_reject_code=554
+#  postconf -e unknown_sender_reject_code = 554 ## TODO unknown option in postfix?
+  postconf -e unknown_virtual_alias_reject_code=554
+  postconf -e unknown_virtual_mailbox_reject_code=554
+  postconf -e unverified_recipient_reject_code=554
+  postconf -e unverified_sender_reject_code=554
+fi


### PR DESCRIPTION
Adds an env option to enforce stricter rejects; reducing backscatter.

The is based on information provided at https://willem.com/blog/2019-09-10_fighting-backscatter-spam-at-server-level/

Usage:

Set env var `STRICT_REJECT` to `1` to enforce the following:

````bash
postconf -e smtpd_helo_required=yes
postconf -e invalid_hostname_reject_code=554
postconf -e multi_recipient_bounce_reject_code=554
postconf -e non_fqdn_reject_code=554
postconf -e relay_domains_reject_code=554
postconf -e unknown_address_reject_code=554
postconf -e unknown_client_reject_code=554
postconf -e unknown_hostname_reject_code=554
postconf -e unknown_local_recipient_reject_code=554
postconf -e unknown_relay_recipient_reject_code=554
#  postconf -e unknown_sender_reject_code = 554 ## TODO unknown option in postfix?
postconf -e unknown_virtual_alias_reject_code=554
postconf -e unknown_virtual_mailbox_reject_code=554
postconf -e unverified_recipient_reject_code=554
postconf -e unverified_sender_reject_code=554
````

This also adds an env var `STRICT` that at the moment only enforces `STRICT_REJECT`, but can be used in the future to enforce more things.
