### PR TITLE
support custom postfix setup script

### DIFF
--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -11,6 +11,10 @@ fi
 /app/bin/setup-tls.sh
 /app/bin/setup-opendkim.sh
 
+if [ -x /app/opt/setup-postfix.sh ]; then
+  /app/opt/setup-postfix.sh
+fi
+
 if [ "$*" != "" ]; then
   exec "$@"
   exit $?


### PR DESCRIPTION
Justs adds a hook to change the postfix config after the built in scripts have been run..

The main reason for this is for giving back the control to the user. There are a lot of things we do not want to support via env vars or such like (i.e. `broken_sasl_auth_clients`).

So this allows an own script that can do almost anything to the configuration.

User must mount the script at `/app/opt/setup-postfix.sh` and it must be executable.

User can do almost everything in the script...

````bash
#!/bin/bash

# support broken sasl clients
postmap -e broken_sasl_auth_clients=yes
````




